### PR TITLE
feat(modbus): add testing tool for modbus go tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ PUSHS := $(addsuffix _push,$(DIRS))
 GO_VERSIONS=1.8.7 1.9.4
 GOLANG_TOOLS=$(addprefix golang-tools_,$(GO_VERSIONS))
 GOLANG_TOOLS_PUSHS=$(addsuffix _push,$(GOLANG_TOOLS))
+MODBUS_TOOLS=$(addprefix modbus-tools_,$(GO_VERSIONS))
+MODBUS_TOOLS_PUSHS=$(addsuffix _push,$(MODBUS_TOOLS))
 
 all: docker push
 
@@ -28,3 +30,10 @@ $(GOLANG_TOOLS):
 
 $(GOLANG_TOOLS_PUSHS):
 	docker push gridx/golang-tools:$(subst _push,,$(subst golang-tools_,,$@))
+
+.PHONY: $(MODBUS_TOOLS)
+$(MODBUS_TOOLS): $(GOLANG_TOOLS)
+	docker build -f modbus-tools/Dockerfile -t gridx/modbus-tools:$(subst modbus-tools_,,$@) --build-arg GO_VERSION=$(subst modbus-tools_,,$@) modbus-tools
+
+$(MODBUS_TOOLS_PUSHS):
+	docker push gridx/modbus-tools:$(subst _push,,$(subst modbus-tools_,,$@))

--- a/modbus-tools/Dockerfile
+++ b/modbus-tools/Dockerfile
@@ -1,0 +1,9 @@
+ARG GO_VERSION=
+FROM gridx/golang-tools:${GO_VERSION}
+
+RUN apt-get update && apt-get -y install socat unzip && rm -rf /var/lib/apt/lists/* && \
+    curl http://www.modbusdriver.com/downloads/diagslave.2.12.zip -o diagslave.zip && \
+    mkdir -p bin && \
+    unzip -p diagslave.zip linux/diagslave > bin/diagslave && \
+    rm diagslave.zip && \
+    chmod +x bin/diagslave


### PR DESCRIPTION
In order to run the Modbus lib test suite we need some more tools, including this rather old freeware:
http://www.modbusdriver.com/diagslave.html

I wasn't able to upload a new image, I guess I don't have the right to do it.
