### PR TITLE
feat(images): upgrade kubectl to 1.10.0 in ops-tools

### DIFF
--- a/images/ops-tools/Dockerfile
+++ b/images/ops-tools/Dockerfile
@@ -24,7 +24,7 @@ RUN wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER
 ADD scripts/setup-k8s.sh /usr/local/bin/setup-k8s.sh
 
 # Install kubectl
-ENV KUBECTL_VERSION=1.9.0
+ENV KUBECTL_VERSION=1.10.0
 RUN wget https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/


### PR DESCRIPTION
NOTE: 1.11.0 is already out but has issues with our older clusters